### PR TITLE
Fix command to copy environment example file

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -62,7 +62,7 @@ git clone https://github.com/arcprize/ARC-AGI-3-Agents.git && cd ARC-AGI-3-Agent
 ### 3. Set up environment variables
 
 ```bash
-cp .env-example .env
+cp .env.example .env
 ```
 
 You will need to set the `ARC_API_KEY` in the `.env` file. You can get your ARC_API_KEY from your user profile after registration on the [ARC-AGI-3 website](https://three.arcprize.org).


### PR DESCRIPTION
I think the name of the environment file template is wrong