### PR TITLE
Fix inconsistent filename in quickstart

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -62,7 +62,7 @@ echo 'ARC_API_KEY=your-api-key-here' > .env
 
 ### 3. Play your first game
 
-Create a file called `my-play.py`:
+Create a file called `play.py`:
 
 ```python
 import arc_agi


### PR DESCRIPTION
Fixes #16. Change `my-play.py` to `play.py` to match the run command.