### PR TITLE
Clarify score cap explanation in methodology

### DIFF
--- a/methodology.mdx
+++ b/methodology.mdx
@@ -51,7 +51,7 @@ level_score = (human_baseline_actions / ai_actions) ^ 2
 
 The maximum score per level is capped at **1.15x** human baseline. If an AI discovers a shortcut and completes a level faster than humans, it can receive at most 1.15.
 
-This ensures a single subpar level does not disproportionately drag down the overall score for an AI that generalizes well across an entire game.
+This keeps any single level from dominating the overall game score, so the score reflects consistent performance rather than one standout run.
 
 ### Per-Game Aggregation
 


### PR DESCRIPTION
The [Per-Level Score Cap](https://docs.arcprize.org/methodology#per-level-score-cap) section of the methodology page currently reads:

> The maximum score per level is capped at 1.15x human baseline. If an AI discovers a shortcut and completes a level faster than humans, it can receive at most 1.15.
>
> This ensures a single subpar level does not disproportionately drag down the overall score for an AI that generalizes well across an entire game.

The second sentence seems backwards. A cap is a ceiling, so it can only pull an outlier high score down, not keep a subpar level from dragging the score down. The cap's actual effect is to stop one unusually efficient level from dominating the weighted average.

Proposed wording:

> This keeps any single level from dominating the overall game score, so the score reflects consistent performance rather than one standout run.