### PR TITLE
Fix typo in AI actions scoring example

### DIFF
--- a/methodology.mdx
+++ b/methodology.mdx
@@ -45,7 +45,7 @@ level_score = (human_baseline_actions / ai_actions) ^ 2
 
 - If human baseline is 10 actions and AI takes 10 → level score is 1.0 (100%)
 - If human baseline is 10 actions and AI takes 20 → level score is 0.25 (25%)
-- If human baseline is 10 actions and AI takes 1,00 → level score is 0.01 (1%)
+- If human baseline is 10 actions and AI takes 100 → level score is 0.01 (1%)
 
 ### Per-Level Score Cap
 


### PR DESCRIPTION
This PR simply removes an unnecessary comma from `1,00` in the [Per Level Scoring](https://docs.arcprize.org/methodology#per-level-scoring) docs.